### PR TITLE
Standardize imports for tests

### DIFF
--- a/tests/test_framework_integration.py
+++ b/tests/test_framework_integration.py
@@ -18,12 +18,12 @@ from langchain_core.tools import tool
 # Suppress Pydantic V2 deprecation warnings from LangChain
 warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*__fields__.*")
 
-from src.agents.rollback_agent import RollbackAgent
-from src.database.repositories.checkpoint_repository import CheckpointRepository
-from src.database.repositories.internal_session_repository import InternalSessionRepository
-from src.database.repositories.external_session_repository import ExternalSessionRepository
-from src.database.repositories.user_repository import UserRepository
-from src.sessions.external_session import ExternalSession
+from src.agentgit.agents.rollback_agent import RollbackAgent
+from src.agentgit.database.repositories.checkpoint_repository import CheckpointRepository
+from src.agentgit.database.repositories.internal_session_repository import InternalSessionRepository
+from src.agentgit.database.repositories.external_session_repository import ExternalSessionRepository
+from src.agentgit.database.repositories.user_repository import UserRepository
+from src.agentgit.sessions.external_session import ExternalSession
 
 
 # Sample tools for testing various scenarios

--- a/tests/test_rollback_branching_real_llm.py
+++ b/tests/test_rollback_branching_real_llm.py
@@ -18,12 +18,12 @@ from langchain_core.tools import tool
 # Suppress Pydantic V2 deprecation warnings from LangChain
 warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*__fields__.*")
 
-from src.agents.rollback_agent import RollbackAgent
-from src.database.repositories.checkpoint_repository import CheckpointRepository
-from src.database.repositories.internal_session_repository import InternalSessionRepository
-from src.database.repositories.external_session_repository import ExternalSessionRepository
-from src.database.repositories.user_repository import UserRepository
-from src.sessions.external_session import ExternalSession
+from src.agentgit.agents.rollback_agent import RollbackAgent
+from src.agentgit.database.repositories.checkpoint_repository import CheckpointRepository
+from src.agentgit.database.repositories.internal_session_repository import InternalSessionRepository
+from src.agentgit.database.repositories.external_session_repository import ExternalSessionRepository
+from src.agentgit.database.repositories.user_repository import UserRepository
+from src.agentgit.sessions.external_session import ExternalSession
 
 
 # Simple tools for testing

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -16,15 +16,15 @@ from langchain_openai import ChatOpenAI
 # Suppress Pydantic V2 deprecation warnings from LangChain
 warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*__fields__.*")
 
-from src.sessions.external_session import ExternalSession
-from src.sessions.internal_session import InternalSession
-from src.database.repositories.external_session_repository import ExternalSessionRepository
-from src.database.repositories.internal_session_repository import InternalSessionRepository
-from src.database.repositories.checkpoint_repository import CheckpointRepository
-from src.database.repositories.user_repository import UserRepository
-from src.auth.user import User
-from src.agents.agent_service import AgentService
-from src.checkpoints.checkpoint import Checkpoint
+from src.agentgit.sessions.external_session import ExternalSession
+from src.agentgit.sessions.internal_session import InternalSession
+from src.agentgit.database.repositories.external_session_repository import ExternalSessionRepository
+from src.agentgit.database.repositories.internal_session_repository import InternalSessionRepository
+from src.agentgit.database.repositories.checkpoint_repository import CheckpointRepository
+from src.agentgit.database.repositories.user_repository import UserRepository
+from src.agentgit.auth.user import User
+from src.agentgit.agents.agent_service import AgentService
+from src.agentgit.checkpoints.checkpoint import Checkpoint
 
 
 class TestSessionManagement(unittest.TestCase):

--- a/tests/test_tool_reversal.py
+++ b/tests/test_tool_reversal.py
@@ -19,13 +19,13 @@ from langchain_core.tools import tool
 # Suppress Pydantic V2 deprecation warnings from LangChain
 warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*__fields__.*")
 
-from src.agents.rollback_agent import RollbackAgent
-from src.checkpoints.checkpoint import Checkpoint
-from src.database.repositories.checkpoint_repository import CheckpointRepository
-from src.database.repositories.internal_session_repository import InternalSessionRepository
-from src.database.repositories.external_session_repository import ExternalSessionRepository
-from src.database.repositories.user_repository import UserRepository
-from src.sessions.external_session import ExternalSession
+from src.agentgit.agents.rollback_agent import RollbackAgent
+from src.agentgit.checkpoints.checkpoint import Checkpoint
+from src.agentgit.database.repositories.checkpoint_repository import CheckpointRepository
+from src.agentgit.database.repositories.internal_session_repository import InternalSessionRepository
+from src.agentgit.database.repositories.external_session_repository import ExternalSessionRepository
+from src.agentgit.database.repositories.user_repository import UserRepository
+from src.agentgit.sessions.external_session import ExternalSession
 
 
 class TestToolReversal(unittest.TestCase):

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -10,9 +10,9 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import unittest
 import tempfile
 
-from src.auth.auth_service import AuthService
-from src.auth.user import User
-from src.database.repositories.user_repository import UserRepository
+from src.agentgit.auth.auth_service import AuthService
+from src.agentgit.auth.user import User
+from src.agentgit.database.repositories.user_repository import UserRepository
 
 
 class TestUserManagement(unittest.TestCase):


### PR DESCRIPTION
Why:
- Imports were mixed between legacy `src.*` and package `agentgit.*`, which caused confusion and inconsistent execution.

What changed:
- ONLY TESTS `from src.*` to `from src.agentgit.*` as current structure
- test_usage unchanged
- No functional logic changes