### PR TITLE
Feat/checkpoint diff

### DIFF
--- a/examples/cli_chat.py
+++ b/examples/cli_chat.py
@@ -28,6 +28,7 @@ from agentgit.database.repositories.external_session_repository import ExternalS
 from agentgit.database.repositories.internal_session_repository import InternalSessionRepository
 from agentgit.database.repositories.checkpoint_repository import CheckpointRepository
 from agentgit.database.db_config import get_database_path
+from agentgit.checkpoints.diff import CheckpointDiffer, DiffRenderer
 
 
 class Color:

--- a/examples/cli_chat.py
+++ b/examples/cli_chat.py
@@ -65,7 +65,8 @@ class MenuChoice(Enum):
     ROLLBACK = "4"
     VIEW_HISTORY = "5"
     BRANCH_INFO = "6"
-    BACK_TO_MAIN = "7"
+    DIFF_CHECKPOINTS = "7"
+    BACK_TO_MAIN = "8"
 
 
 class CLIChatApp:
@@ -325,6 +326,7 @@ class CLIChatApp:
                 (MenuChoice.ROLLBACK.value, "Rollback to checkpoint"),
                 (MenuChoice.VIEW_HISTORY.value, "View conversation history"),
                 (MenuChoice.BRANCH_INFO.value, "View branch information"),
+                (MenuChoice.DIFF_CHECKPOINTS.value, "Compare checkpoints (diff)"),
                 (MenuChoice.BACK_TO_MAIN.value, "Back to main menu")
             ])
             
@@ -342,6 +344,8 @@ class CLIChatApp:
                 self.view_history()
             elif choice == MenuChoice.BRANCH_INFO.value:
                 self.view_branch_info()
+            elif choice == MenuChoice.DIFF_CHECKPOINTS.value:
+                self.diff_checkpoints()
             elif choice == MenuChoice.BACK_TO_MAIN.value:
                 break
             else:
@@ -631,6 +635,51 @@ class CLIChatApp:
                 self.print_error(message)
         else:
             self.print_info("No changes made")
+    
+    def diff_checkpoints(self):
+        """Compare two checkpoints and show differences."""
+        if not self.current_agent.internal_session:
+            self.print_warning("No internal session active")
+            return
+        
+        checkpoints = self.checkpoint_repo.get_by_internal_session(
+            self.current_agent.internal_session.id
+        )
+        
+        if len(checkpoints) < 2:
+            self.print_warning("Need at least 2 checkpoints to compare")
+            return
+        
+        # Display checkpoints for selection
+        print(f"\n{Color.BOLD}Available Checkpoints:{Color.ENDC}")
+        for i, cp in enumerate(checkpoints):
+            name = cp.checkpoint_name or f"Checkpoint {cp.id}"
+            print(f"  {i}: {Color.BOLD}[{cp.id}]{Color.ENDC} {name}")
+        
+        # Get checkpoint IDs
+        id_a_str = self.get_input("Enter first checkpoint index")
+        id_b_str = self.get_input("Enter second checkpoint index")
+        
+        try:
+            id_a = int(id_a_str)
+            id_b = int(id_b_str)
+            
+            if id_a < 0 or id_a >= len(checkpoints) or id_b < 0 or id_b >= len(checkpoints):
+                self.print_error("Invalid checkpoint indices")
+                return
+            
+            checkpoint_a = checkpoints[id_a]
+            checkpoint_b = checkpoints[id_b]
+            
+            # Perform diff
+            diff_result = CheckpointDiffer.diff(checkpoint_a, checkpoint_b)
+            
+            # Render and display
+            output = DiffRenderer.render_text(diff_result, use_color=True)
+            print(f"\n{output}\n")
+            
+        except ValueError:
+            self.print_error("Please enter valid checkpoint indices")
     
     def list_sessions(self):
         """List all user sessions."""

--- a/src/agentgit/checkpoints/diff.py
+++ b/src/agentgit/checkpoints/diff.py
@@ -1,0 +1,370 @@
+"""Diff functionality for comparing checkpoints.
+
+Provides utilities to compare two checkpoints and identify differences in state,
+conversation history, and tool invocations.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+from enum import Enum
+import json
+
+
+class ChangeType(Enum):
+    """Type of change detected in a diff."""
+    ADDED = "added"
+    REMOVED = "removed"
+    MODIFIED = "modified"
+
+
+@dataclass
+class StateChange:
+    """Represents a change in session state."""
+    path: str
+    change_type: ChangeType
+    old_value: Any = None
+    new_value: Any = None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "path": self.path,
+            "change_type": self.change_type.value,
+            "old_value": self.old_value,
+            "new_value": self.new_value,
+        }
+
+
+@dataclass
+class ToolInvocationChange:
+    """Represents a tool invocation in the diff."""
+    index: int
+    tool_name: str
+    args: Dict[str, Any]
+    result: Optional[str] = None
+    success: bool = True
+    error_message: Optional[str] = None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "index": self.index,
+            "tool_name": self.tool_name,
+            "args": self.args,
+            "result": self.result,
+            "success": self.success,
+            "error_message": self.error_message,
+        }
+
+
+@dataclass
+class DiffReport:
+    """Complete diff report between two checkpoints."""
+    checkpoint_a_id: int
+    checkpoint_b_id: int
+    state_changes: List[StateChange] = field(default_factory=list)
+    tool_invocations: List[ToolInvocationChange] = field(default_factory=list)
+    conversation_diff: Dict[str, Any] = field(default_factory=dict)
+    metadata_diff: Dict[str, Any] = field(default_factory=dict)
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert report to dictionary."""
+        return {
+            "checkpoint_a_id": self.checkpoint_a_id,
+            "checkpoint_b_id": self.checkpoint_b_id,
+            "state_changes": [s.to_dict() for s in self.state_changes],
+            "tool_invocations": [t.to_dict() for t in self.tool_invocations],
+            "conversation_diff": self.conversation_diff,
+            "metadata_diff": self.metadata_diff,
+        }
+    
+    def to_json(self) -> str:
+        """Convert report to JSON string."""
+        return json.dumps(self.to_dict(), indent=2, default=str)
+
+
+def _flatten_dict(d: Dict[str, Any], parent_key: str = "", sep: str = ".") -> Dict[str, Any]:
+    """Flatten a nested dictionary with dot notation paths."""
+    items = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(_flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)
+
+
+def _compare_dicts(old: Dict[str, Any], new: Dict[str, Any]) -> List[StateChange]:
+    """Compare two dictionaries and return state changes."""
+    changes = []
+    
+    # Flatten both dicts for comparison
+    old_flat = _flatten_dict(old)
+    new_flat = _flatten_dict(new)
+    
+    # Find all keys
+    all_keys = set(old_flat.keys()) | set(new_flat.keys())
+    
+    for key in sorted(all_keys):
+        old_val = old_flat.get(key)
+        new_val = new_flat.get(key)
+        
+        if key not in old_flat:
+            changes.append(StateChange(
+                path=key,
+                change_type=ChangeType.ADDED,
+                new_value=new_val
+            ))
+        elif key not in new_flat:
+            changes.append(StateChange(
+                path=key,
+                change_type=ChangeType.REMOVED,
+                old_value=old_val
+            ))
+        elif old_val != new_val:
+            changes.append(StateChange(
+                path=key,
+                change_type=ChangeType.MODIFIED,
+                old_value=old_val,
+                new_value=new_val
+            ))
+    
+    return changes
+
+
+def _compare_tool_invocations(
+    old_tools: List[Dict[str, Any]],
+    new_tools: List[Dict[str, Any]]
+) -> List[ToolInvocationChange]:
+    """Extract tool invocations that exist in new but not in old."""
+    changes = []
+    
+    # Only show tools in B that are after A
+    # Assume tools are chronologically ordered
+    old_count = len(old_tools)
+    new_tools_after = new_tools[old_count:]
+    
+    for idx, tool_inv in enumerate(new_tools_after, start=old_count):
+        changes.append(ToolInvocationChange(
+            index=idx,
+            tool_name=tool_inv.get("tool_name", tool_inv.get("tool", "unknown")),
+            args=tool_inv.get("args", {}),
+            result=tool_inv.get("result"),
+            success=tool_inv.get("success", True),
+            error_message=tool_inv.get("error_message")
+        ))
+    
+    return changes
+
+
+def _compare_conversations(
+    old_history: List[Dict[str, Any]],
+    new_history: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Compare conversation histories."""
+    old_count = len(old_history)
+    new_count = len(new_history)
+    
+    return {
+        "old_length": old_count,
+        "new_length": new_count,
+        "messages_added": new_count - old_count,
+        "new_messages": new_history[old_count:] if new_count > old_count else []
+    }
+
+
+def _order_checkpoints(checkpoint_a, checkpoint_b):
+    """Return checkpoints ordered from older to newer."""
+    created_a = getattr(checkpoint_a, "created_at", None)
+    created_b = getattr(checkpoint_b, "created_at", None)
+    if created_a and created_b:
+        if created_a <= created_b:
+            return checkpoint_a, checkpoint_b
+        return checkpoint_b, checkpoint_a
+    
+    id_a = getattr(checkpoint_a, "id", None)
+    id_b = getattr(checkpoint_b, "id", None)
+    if id_a is not None and id_b is not None:
+        if id_a <= id_b:
+            return checkpoint_a, checkpoint_b
+        return checkpoint_b, checkpoint_a
+    
+    history_a = checkpoint_a.conversation_history or []
+    history_b = checkpoint_b.conversation_history or []
+    if len(history_a) != len(history_b):
+        if len(history_a) <= len(history_b):
+            return checkpoint_a, checkpoint_b
+        return checkpoint_b, checkpoint_a
+    
+    tools_a = checkpoint_a.tool_invocations or []
+    tools_b = checkpoint_b.tool_invocations or []
+    if len(tools_a) != len(tools_b):
+        if len(tools_a) <= len(tools_b):
+            return checkpoint_a, checkpoint_b
+        return checkpoint_b, checkpoint_a
+    
+    return checkpoint_a, checkpoint_b
+
+
+def compare_checkpoints(checkpoint_a, checkpoint_b) -> DiffReport:
+    """
+    Compare two checkpoints and return a detailed diff report.
+    
+    Args:
+        checkpoint_a: First checkpoint
+        checkpoint_b: Second checkpoint
+    
+    Returns:
+        DiffReport with all differences. Checkpoints are ordered internally
+        from older to newer before comparison.
+    """
+    older, newer = _order_checkpoints(checkpoint_a, checkpoint_b)
+    report = DiffReport(
+        checkpoint_a_id=older.id,
+        checkpoint_b_id=newer.id
+    )
+    
+    # Compare session state
+    old_state = older.session_state or {}
+    new_state = newer.session_state or {}
+    report.state_changes = _compare_dicts(old_state, new_state)
+    
+    # Compare tool invocations
+    old_tools = older.tool_invocations or []
+    new_tools = newer.tool_invocations or []
+    report.tool_invocations = _compare_tool_invocations(old_tools, new_tools)
+    
+    # Compare conversation history
+    old_conv = older.conversation_history or []
+    new_conv = newer.conversation_history or []
+    report.conversation_diff = _compare_conversations(old_conv, new_conv)
+    
+    # Compare metadata
+    old_meta = older.metadata or {}
+    new_meta = newer.metadata or {}
+    report.metadata_diff = {
+        "old_metadata": old_meta,
+        "new_metadata": new_meta,
+    }
+    
+    return report
+
+
+def format_diff_report(report: DiffReport, json_output: bool = False) -> str:
+    """
+    Format a diff report for display.
+    
+    Args:
+        report: The DiffReport to format
+        json_output: If True, return JSON; otherwise human-readable text
+    
+    Returns:
+        Formatted report as string
+    """
+    if json_output:
+        return report.to_json()
+    
+    lines = []
+    lines.append(f"Checkpoint Diff: {report.checkpoint_a_id} → {report.checkpoint_b_id}")
+    lines.append("=" * 70)
+    
+    # State changes
+    if report.state_changes:
+        lines.append("\n📊 STATE CHANGES:")
+        lines.append("-" * 70)
+        
+        added = [c for c in report.state_changes if c.change_type == ChangeType.ADDED]
+        removed = [c for c in report.state_changes if c.change_type == ChangeType.REMOVED]
+        modified = [c for c in report.state_changes if c.change_type == ChangeType.MODIFIED]
+        
+        if added:
+            lines.append("\n  ➕ ADDED:")
+            for change in added:
+                lines.append(f"    {change.path}: {change.new_value}")
+        
+        if removed:
+            lines.append("\n  ➖ REMOVED:")
+            for change in removed:
+                lines.append(f"    {change.path}: {change.old_value}")
+        
+        if modified:
+            lines.append("\n  🔄 MODIFIED:")
+            for change in modified:
+                lines.append(f"    {change.path}:")
+                lines.append(f"      - {change.old_value}")
+                lines.append(f"      + {change.new_value}")
+    else:
+        lines.append("\n📊 STATE CHANGES: None")
+    
+    # Tool invocations
+    if report.tool_invocations:
+        lines.append("\n\n🔧 TOOL INVOCATIONS (after checkpoint A):")
+        lines.append("-" * 70)
+        for tool in report.tool_invocations:
+            status = "✓" if tool.success else "✗"
+            lines.append(f"\n  {status} [{tool.index}] {tool.tool_name}")
+            if tool.args:
+                lines.append(f"      Args: {tool.args}")
+            if tool.result:
+                lines.append(f"      Result: {tool.result}")
+            if tool.error_message:
+                lines.append(f"      Error: {tool.error_message}")
+    else:
+        lines.append("\n\n🔧 TOOL INVOCATIONS: None")
+    
+    # Conversation changes
+    conv_diff = report.conversation_diff
+    lines.append(f"\n\n💬 CONVERSATION:")
+    lines.append("-" * 70)
+    lines.append(f"  Messages in A: {conv_diff.get('old_length', 0)}")
+    lines.append(f"  Messages in B: {conv_diff.get('new_length', 0)}")
+    lines.append(f"  Messages added: {conv_diff.get('messages_added', 0)}")
+    
+    if conv_diff.get('new_messages'):
+        lines.append(f"\n  New messages:")
+        for msg in conv_diff['new_messages']:
+            role = msg.get('role', 'unknown').upper()
+            content = msg.get('content', '')[:100]
+            lines.append(f"    [{role}] {content}...")
+    
+    lines.append("\n" + "=" * 70)
+    return "\n".join(lines)
+
+
+class CheckpointDiffer:
+    """Compatibility wrapper for checkpoint diffing."""
+    
+    @staticmethod
+    def diff(checkpoint_a, checkpoint_b) -> DiffReport:
+        """Compare two checkpoints and return a diff report."""
+        return compare_checkpoints(checkpoint_a, checkpoint_b)
+
+
+class DiffRenderer:
+    """Compatibility wrapper for diff rendering."""
+    
+    @staticmethod
+    def render_text(report: DiffReport, use_color: bool = False) -> str:
+        """Render a diff report as text, optionally with ANSI colors."""
+        output = format_diff_report(report, json_output=False)
+        if not use_color:
+            return output
+        
+        # Simple ANSI styling for headers and section labels.
+        bold = "\033[1m"
+        cyan = "\033[96m"
+        dim = "\033[2m"
+        reset = "\033[0m"
+        
+        lines = []
+        for line in output.splitlines():
+            if line.startswith("Checkpoint Diff:"):
+                lines.append(f"{bold}{line}{reset}")
+            elif line.startswith("=" * 70):
+                lines.append(f"{dim}{line}{reset}")
+            elif "STATE CHANGES" in line or "TOOL INVOCATIONS" in line or "CONVERSATION" in line:
+                lines.append(f"{cyan}{bold}{line}{reset}")
+            else:
+                lines.append(line)
+        return "\n".join(lines)

--- a/tests/test_checkpoint_diff.py
+++ b/tests/test_checkpoint_diff.py
@@ -1,0 +1,342 @@
+"""Tests for checkpoint diff functionality."""
+
+import pytest
+import json
+from datetime import datetime
+
+from src.agentgit.checkpoints.checkpoint import Checkpoint
+from src.agentgit.checkpoints.diff import (
+    compare_checkpoints,
+    format_diff_report,
+    StateChange,
+    ChangeType,
+    ToolInvocationChange,
+    DiffReport,
+    _flatten_dict,
+    _compare_dicts,
+    _compare_tool_invocations,
+)
+
+
+class TestFlattenDict:
+    """Test dictionary flattening."""
+    
+    def test_flatten_simple_dict(self):
+        """Test flattening a simple dict."""
+        d = {"a": 1, "b": 2}
+        result = _flatten_dict(d)
+        assert result == {"a": 1, "b": 2}
+    
+    def test_flatten_nested_dict(self):
+        """Test flattening a nested dict."""
+        d = {"a": {"b": {"c": 1}}, "x": 2}
+        result = _flatten_dict(d)
+        assert result == {"a.b.c": 1, "x": 2}
+    
+    def test_flatten_mixed_dict(self):
+        """Test flattening mixed nested and flat keys."""
+        d = {
+            "user": {"name": "Alice", "profile": {"age": 30}},
+            "count": 5
+        }
+        result = _flatten_dict(d)
+        assert "user.name" in result
+        assert "user.profile.age" in result
+        assert "count" in result
+
+
+class TestCompareDicts:
+    """Test dict comparison."""
+    
+    def test_no_changes(self):
+        """Test comparing identical dicts."""
+        old = {"a": 1, "b": 2}
+        new = {"a": 1, "b": 2}
+        changes = _compare_dicts(old, new)
+        assert len(changes) == 0
+    
+    def test_added_key(self):
+        """Test added keys."""
+        old = {"a": 1}
+        new = {"a": 1, "b": 2}
+        changes = _compare_dicts(old, new)
+        
+        assert len(changes) == 1
+        assert changes[0].path == "b"
+        assert changes[0].change_type == ChangeType.ADDED
+        assert changes[0].new_value == 2
+    
+    def test_removed_key(self):
+        """Test removed keys."""
+        old = {"a": 1, "b": 2}
+        new = {"a": 1}
+        changes = _compare_dicts(old, new)
+        
+        assert len(changes) == 1
+        assert changes[0].path == "b"
+        assert changes[0].change_type == ChangeType.REMOVED
+        assert changes[0].old_value == 2
+    
+    def test_modified_value(self):
+        """Test modified values."""
+        old = {"a": 1, "b": "old"}
+        new = {"a": 1, "b": "new"}
+        changes = _compare_dicts(old, new)
+        
+        assert len(changes) == 1
+        assert changes[0].path == "b"
+        assert changes[0].change_type == ChangeType.MODIFIED
+        assert changes[0].old_value == "old"
+        assert changes[0].new_value == "new"
+    
+    def test_nested_changes(self):
+        """Test changes in nested dicts."""
+        old = {"user": {"name": "Alice", "age": 30}}
+        new = {"user": {"name": "Alice", "age": 31, "city": "NYC"}}
+        changes = _compare_dicts(old, new)
+        
+        assert len(changes) == 2
+        paths = {c.path for c in changes}
+        assert "user.age" in paths
+        assert "user.city" in paths
+
+
+class TestCompareToolInvocations:
+    """Test tool invocation comparison."""
+    
+    def test_no_new_tools(self):
+        """Test when no new tools are invoked."""
+        old = [{"tool_name": "tool1", "args": {}}]
+        new = [{"tool_name": "tool1", "args": {}}]
+        changes = _compare_tool_invocations(old, new)
+        assert len(changes) == 0
+    
+    def test_new_tools_added(self):
+        """Test when new tools are added."""
+        old = [{"tool_name": "tool1", "args": {"x": 1}}]
+        new = [
+            {"tool_name": "tool1", "args": {"x": 1}},
+            {"tool_name": "tool2", "args": {"y": 2}, "success": True},
+            {"tool_name": "tool3", "args": {}, "success": False, "error_message": "Failed"}
+        ]
+        changes = _compare_tool_invocations(old, new)
+        
+        assert len(changes) == 2
+        assert changes[0].tool_name == "tool2"
+        assert changes[0].index == 1
+        assert changes[0].success is True
+        assert changes[1].tool_name == "tool3"
+        assert changes[1].success is False
+        assert changes[1].error_message == "Failed"
+
+
+class TestDiffReport:
+    """Test DiffReport class."""
+    
+    def test_report_creation(self):
+        """Test creating a diff report."""
+        report = DiffReport(checkpoint_a_id=1, checkpoint_b_id=2)
+        assert report.checkpoint_a_id == 1
+        assert report.checkpoint_b_id == 2
+        assert len(report.state_changes) == 0
+        assert len(report.tool_invocations) == 0
+    
+    def test_report_to_dict(self):
+        """Test converting report to dict."""
+        report = DiffReport(
+            checkpoint_a_id=1,
+            checkpoint_b_id=2,
+            state_changes=[StateChange("key", ChangeType.ADDED, new_value=1)]
+        )
+        d = report.to_dict()
+        assert d["checkpoint_a_id"] == 1
+        assert d["checkpoint_b_id"] == 2
+        assert len(d["state_changes"]) == 1
+    
+    def test_report_to_json(self):
+        """Test converting report to JSON."""
+        report = DiffReport(checkpoint_a_id=1, checkpoint_b_id=2)
+        json_str = report.to_json()
+        parsed = json.loads(json_str)
+        assert parsed["checkpoint_a_id"] == 1
+        assert parsed["checkpoint_b_id"] == 2
+
+
+class TestCompareCheckpoints:
+    """Integration tests for checkpoint comparison."""
+    
+    def test_compare_identical_checkpoints(self):
+        """Test comparing identical checkpoints."""
+        cp = Checkpoint(
+            id=1,
+            internal_session_id=1,
+            session_state={"counter": 5},
+            tool_invocations=[{"tool_name": "tool1", "args": {}}]
+        )
+        
+        report = compare_checkpoints(cp, cp)
+        assert len(report.state_changes) == 0
+        assert len(report.tool_invocations) == 0
+    
+    def test_compare_with_state_changes(self):
+        """Test comparing checkpoints with state changes."""
+        cp_a = Checkpoint(
+            id=1,
+            internal_session_id=1,
+            session_state={"counter": 5, "name": "Alice"},
+            tool_invocations=[]
+        )
+        
+        cp_b = Checkpoint(
+            id=2,
+            internal_session_id=1,
+            session_state={"counter": 10, "name": "Alice", "age": 30},
+            tool_invocations=[]
+        )
+        
+        report = compare_checkpoints(cp_a, cp_b)
+        
+        assert len(report.state_changes) == 2
+        paths = {c.path for c in report.state_changes}
+        assert "counter" in paths
+        assert "age" in paths
+    
+    def test_compare_with_tool_invocations(self):
+        """Test comparing checkpoints with tool invocations."""
+        cp_a = Checkpoint(
+            id=1,
+            internal_session_id=1,
+            session_state={},
+            tool_invocations=[
+                {"tool_name": "read_file", "args": {"path": "/file1"}, "success": True}
+            ]
+        )
+        
+        cp_b = Checkpoint(
+            id=2,
+            internal_session_id=1,
+            session_state={},
+            tool_invocations=[
+                {"tool_name": "read_file", "args": {"path": "/file1"}, "success": True},
+                {"tool_name": "write_file", "args": {"path": "/file2"}, "success": True},
+                {"tool_name": "delete_file", "args": {"path": "/file3"}, "success": False, "error_message": "Permission denied"}
+            ]
+        )
+        
+        report = compare_checkpoints(cp_a, cp_b)
+        
+        assert len(report.tool_invocations) == 2
+        assert report.tool_invocations[0].tool_name == "write_file"
+        assert report.tool_invocations[1].tool_name == "delete_file"
+        assert report.tool_invocations[1].success is False
+    
+    def test_compare_with_conversation_changes(self):
+        """Test comparing conversation histories."""
+        cp_a = Checkpoint(
+            id=1,
+            internal_session_id=1,
+            conversation_history=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there"}
+            ]
+        )
+        
+        cp_b = Checkpoint(
+            id=2,
+            internal_session_id=1,
+            conversation_history=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there"},
+                {"role": "user", "content": "How are you?"},
+                {"role": "assistant", "content": "I'm doing well"}
+            ]
+        )
+        
+        report = compare_checkpoints(cp_a, cp_b)
+        
+        assert report.conversation_diff["old_length"] == 2
+        assert report.conversation_diff["new_length"] == 4
+        assert report.conversation_diff["messages_added"] == 2
+        assert len(report.conversation_diff["new_messages"]) == 2
+
+    def test_compare_orders_by_created_at(self):
+        """Test that checkpoints are ordered by created_at when comparing."""
+        older_time = datetime(2024, 1, 1, 12, 0, 0)
+        newer_time = datetime(2024, 1, 2, 12, 0, 0)
+        
+        cp_old = Checkpoint(
+            id=10,
+            internal_session_id=1,
+            created_at=older_time,
+            conversation_history=[
+                {"role": "user", "content": "Hello"}
+            ]
+        )
+        
+        cp_new = Checkpoint(
+            id=1,
+            internal_session_id=1,
+            created_at=newer_time,
+            conversation_history=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"}
+            ]
+        )
+        
+        # Pass them in reverse order; report should still be old -> new
+        report = compare_checkpoints(cp_new, cp_old)
+        
+        assert report.checkpoint_a_id == 10
+        assert report.checkpoint_b_id == 1
+        assert report.conversation_diff["messages_added"] == 1
+
+
+class TestFormatDiffReport:
+    """Test formatting diff reports."""
+    
+    def test_format_text_output(self):
+        """Test text formatting."""
+        cp_a = Checkpoint(id=1, session_state={"a": 1})
+        cp_b = Checkpoint(id=2, session_state={"a": 2, "b": 3})
+        
+        report = compare_checkpoints(cp_a, cp_b)
+        output = format_diff_report(report, json_output=False)
+        
+        assert "Checkpoint Diff: 1 → 2" in output
+        assert "STATE CHANGES" in output
+        assert "TOOL INVOCATIONS" in output
+        assert "CONVERSATION" in output
+    
+    def test_format_json_output(self):
+        """Test JSON formatting."""
+        cp_a = Checkpoint(id=1, session_state={})
+        cp_b = Checkpoint(id=2, session_state={"key": "value"})
+        
+        report = compare_checkpoints(cp_a, cp_b)
+        output = format_diff_report(report, json_output=True)
+        
+        parsed = json.loads(output)
+        assert parsed["checkpoint_a_id"] == 1
+        assert parsed["checkpoint_b_id"] == 2
+        assert len(parsed["state_changes"]) == 1
+    
+    def test_format_with_tool_failures(self):
+        """Test formatting with failed tools."""
+        report = DiffReport(
+            checkpoint_a_id=1,
+            checkpoint_b_id=2,
+            tool_invocations=[
+                ToolInvocationChange(
+                    index=0,
+                    tool_name="network_call",
+                    args={"url": "http://example.com"},
+                    success=False,
+                    error_message="Connection timeout"
+                )
+            ]
+        )
+        
+        output = format_diff_report(report, json_output=False)
+        assert "network_call" in output
+        assert "Connection timeout" in output
+        assert "✗" in output

--- a/tests/test_checkpoint_diff.py
+++ b/tests/test_checkpoint_diff.py
@@ -1,11 +1,14 @@
 """Tests for checkpoint diff functionality."""
 
-import pytest
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import json
 from datetime import datetime
 
-from src.agentgit.checkpoints.checkpoint import Checkpoint
-from src.agentgit.checkpoints.diff import (
+from agentgit.checkpoints.checkpoint import Checkpoint
+from agentgit.checkpoints.diff import (
     compare_checkpoints,
     format_diff_report,
     StateChange,
@@ -16,6 +19,8 @@ from src.agentgit.checkpoints.diff import (
     _compare_dicts,
     _compare_tool_invocations,
 )
+from dotenv import load_dotenv
+load_dotenv()
 
 
 class TestFlattenDict:

--- a/tests/test_checkpoint_diff.py
+++ b/tests/test_checkpoint_diff.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src"))
 
 import json
 from datetime import datetime
@@ -19,8 +19,6 @@ from agentgit.checkpoints.diff import (
     _compare_dicts,
     _compare_tool_invocations,
 )
-from dotenv import load_dotenv
-load_dotenv()
 
 
 class TestFlattenDict:


### PR DESCRIPTION
Add checkpoint diff support with ordering awareness and CLI menu integration.

**Changes**
- Add checkpoint comparison/reporting utilities with automatic older/newer ordering.
- Add menu option in `examples/cli_chat.py` to compare checkpoints using the diff feature.
- Add tests covering diff ordering behavior.
